### PR TITLE
Fix Messages Sent Back to the Runtime

### DIFF
--- a/artifacttemplates/http%3A%2F%2Fopentosca.org%2Fartifacttemplates/DockerContainer_ContainerManagementInterface-w1/files/org_opentosca_nodetypes_DockerContainer__ContainerManagementInterface.war
+++ b/artifacttemplates/http%3A%2F%2Fopentosca.org%2Fartifacttemplates/DockerContainer_ContainerManagementInterface-w1/files/org_opentosca_nodetypes_DockerContainer__ContainerManagementInterface.war
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d6b20f6ba8e12e20ec8381e8d785f793e2fedc27d0b21c23e3d9956088451a9
-size 28483117
+oid sha256:072e1263ed996fda1269107cd5b2896ac381f4de9bfa29f49eddd05dc984f26d
+size 28301056

--- a/artifacttemplates/http%3A%2F%2Fopentosca.org%2Fartifacttemplates/DockerContainer_ContainerManagementInterface-w1/source/pom.xml
+++ b/artifacttemplates/http%3A%2F%2Fopentosca.org%2Fartifacttemplates/DockerContainer_ContainerManagementInterface-w1/source/pom.xml
@@ -22,11 +22,6 @@
         <!-- LIBRARIES ADDED FOR IMPLEMENTATION ARTIFACT IMPLEMENTATION -->
 
         <dependency>
-            <groupId>org.vngx</groupId>
-            <artifactId>vngx-jsch</artifactId>
-            <version>0.10</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>
@@ -102,6 +97,12 @@
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
             <version>3.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>2.1.6</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Currently, by sending the response back to the container, the message is not encoded. This is fixed in this PR.