### PR TITLE
Add host.docker.internal as extra host

### DIFF
--- a/artifacttemplates/http%3A%2F%2Fopentosca.org%2Fartifacttemplates/DockerEngine_DockerEngine-Interface-w1/files/org_opentosca_artifactTemplates_DockerEngine__InterfaceDockerEngine.war
+++ b/artifacttemplates/http%3A%2F%2Fopentosca.org%2Fartifacttemplates/DockerEngine_DockerEngine-Interface-w1/files/org_opentosca_artifactTemplates_DockerEngine__InterfaceDockerEngine.war
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52334e0e480579c994bcca14cec6595c25838d4ffb5269b2ce81df0dd53ad16a
-size 47152137
+oid sha256:d571915c42fe8132fa4eace246bdd3ae4dd4ad8b1d39747137f00905f10369fe
+size 47152191

--- a/artifacttemplates/http%3A%2F%2Fopentosca.org%2Fartifacttemplates/DockerEngine_DockerEngine-Interface-w1/source/src/main/java/org/opentosca/artifacttemplates/dockerengine/DockerEngineInterfaceDockerEngineEndpoint.java
+++ b/artifacttemplates/http%3A%2F%2Fopentosca.org%2Fartifacttemplates/DockerEngine_DockerEngine-Interface-w1/source/src/main/java/org/opentosca/artifacttemplates/dockerengine/DockerEngineInterfaceDockerEngineEndpoint.java
@@ -353,6 +353,7 @@ public class DockerEngineInterfaceDockerEngineEndpoint {
                         .withBinds(new Bind(hostVolPath, volume))
                         .withVolumes(volume)
                         .withDevices(devices)
+                        .withExtraHosts("host.docker.internal:host-gateway")
                         .withCmd("-v")
                         .withPrivileged(privileged)
                         .exec();
@@ -365,6 +366,7 @@ public class DockerEngineInterfaceDockerEngineEndpoint {
                         .withTty(true)
                         .withLinks(links)
                         .withDevices(devices)
+                        .withExtraHosts("host.docker.internal:host-gateway")
                         .withPrivileged(privileged)
                         .exec();
             }


### PR DESCRIPTION
To allow the communication between containers in the dind, this PR adds host.docker.internal as an extra host to each container.

Signed-off-by: Marvin Bechtold <marvin.bechtold.dev@gmail.com>